### PR TITLE
Support user defined sass options

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,6 +66,10 @@ let settings = {
     },
     browserslist: ["> 2%", "last 2 versions", "IE 11", "not dead"],
     sassSourcemaps: true,
+    /** @type {Omit<import("sass-embedded").Options<"async">, "outputStyle">} */
+    sassOptions: {
+      quietDeps: true,
+    },
   },
   sprite: {
     width: 24,
@@ -196,9 +200,9 @@ function buildSass() {
   })
     .pipe(
       sass({
+        ...settings.compile.sassOptions,
         outputStyle: "compressed",
         includePaths: buildSettings.includes,
-        silenceDeprecations: ["mixed-decls"]
       }).on("error", handleError)
     )
     .pipe(replace(/\buswds @version\b/g, `based on uswds v${pkg}`))


### PR DESCRIPTION
Let end users define options that will be passed to `sass-embedded` during compilation. Omit `outputStyle` from configurable options to preserve sourcemaps paths: https://github.com/uswds/uswds-compile/pull/79. Note that `includePaths` is a legacy API option, so it doesn't need to be included in the types `Omit<>`.

Provide a good out-of-box experience by defaulting to sass options `{quietDeps: true}`, so that deprecation warnings related to the user's own styles are raised, but those from USWDS styles are suppressed.